### PR TITLE
Hermes bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ These are the top-level admins of TCD's infrastructure. They approve changes to 
 - Cluster `arealmreborn` (FF14 DC themed)
   - Node pool `primal`
     - Nodes: 1-5, autoscales
+      - Hermes Pod

--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -17,3 +17,25 @@ resource "digitalocean_kubernetes_cluster" "main" {
     max_nodes  = 5
   }
 }
+
+provider "kubernetes" {
+  host = digitalocean_kubernetes_cluster.main.kube_config.0.host
+  client_certificate = digitalocean_kubernetes_cluster.main.kube_config.0.client_certificate
+  client_key = digitalocean_kubernetes_cluster.main.kube_config.0.client_key
+  cluster_ca_certificate = digitalocean_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate
+}
+
+resource "kubernetes_persistent_volume_claim" "data" {
+  metadata {
+    name = "data"
+  }
+  spec {
+    access_modes = ["ReadWriteMany"]
+    resources {
+      requests = {
+        storage = "5Gi"
+      }
+    }
+    storage_class_name = "do-block-storage"
+  }
+}

--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -25,17 +25,3 @@ provider "kubernetes" {
   cluster_ca_certificate = digitalocean_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate
 }
 
-resource "kubernetes_persistent_volume_claim" "petit_data" {
-  metadata {
-    name = "petit_data"
-  }
-  spec {
-    access_modes = ["ReadWriteOnce"] # ReadWriteMany and ReadOnlyMany is not supported
-    resources {
-      requests = {
-        storage = "5Gi"
-      }
-    }
-    storage_class_name = "do-block-storage"
-  }
-}

--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -25,12 +25,12 @@ provider "kubernetes" {
   cluster_ca_certificate = digitalocean_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate
 }
 
-resource "kubernetes_persistent_volume_claim" "data" {
+resource "kubernetes_persistent_volume_claim" "petit_data" {
   metadata {
-    name = "data"
+    name = "petit_data"
   }
   spec {
-    access_modes = ["ReadWriteMany"]
+    access_modes = ["ReadWriteOnce"] # ReadWriteMany and ReadOnlyMany is not supported
     resources {
       requests = {
         storage = "5Gi"

--- a/src/hermes.tf
+++ b/src/hermes.tf
@@ -8,9 +8,15 @@ resource "kubernetes_pod" "hermes" {
             name = "hermes"
         }
         volume {
+            name = "petit_data"
             persistent_volume_claim {
-                claim_name = kubernetes_persistent_volume_claim.data.metadata[0].name
+                claim_name = kubernetes_persistent_volume_claim.petit_data.metadata[0].name
             }
+        }
+        volume_mount {
+            name = "petit_data"
+            mount_path = "/hermes/"
+            sub_path = "/hermes/"
         }
     }
 }

--- a/src/hermes.tf
+++ b/src/hermes.tf
@@ -1,0 +1,16 @@
+resource "kubernetes_pod" "hermes" {
+    metadata {
+        name = "hermes"
+    }
+    spec {
+        container {
+            image = "kantenkugel/hermes"
+            name = "hermes"
+        }
+        volume {
+            persistent_volume_claim {
+                claim_name = kubernetes_persistent_volume_claim.data.metadata[0].name
+            }
+        }
+    }
+}

--- a/src/hermes.tf
+++ b/src/hermes.tf
@@ -1,3 +1,18 @@
+resource "kubernetes_persistent_volume_claim" "petit_data" {
+  metadata {
+    name = "petit_data"
+  }
+  spec {
+    access_modes = ["ReadWriteOnce"] # ReadWriteMany and ReadOnlyMany is not supported
+    resources {
+      requests = {
+        storage = "1Gi"
+      }
+    }
+    storage_class_name = "do-block-storage"
+  }
+}
+
 resource "kubernetes_pod" "hermes" {
     metadata {
         name = "hermes"


### PR DESCRIPTION
This PR adds spec for Hermes

## Resource impact
- Allocates a single 1GB DO block storage
- Hermes uses little ram according to Quantenkugel

## Pre-merge ToDo
N/A - No pre-merge things to do

## Checklist
- [x] I ran a formatter on all changes in this PR.
- [x] I have sent any relevant secrets to infrastructure admins.
- [x] I have ensured that any software changes are tested and have passed for the versions included.
- [x] I have added the changes to the resource tree in `README.md`.

## Post-merge
the Hermes PVC needs to be populated with Quantenkugel's copy of guildSettings.json from Discord
