### PR TITLE
Add configuration for projects bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ These are the top-level admins of TCD's infrastructure. They approve changes to 
 - Cluster `arealmreborn` (FF14 DC themed)
   - Node pool `primal`
     - Nodes: 1-5, autoscales
-  - Projects bot pod
+  - Projects Bot
+    - 1 pod w/ `thecodingden/projects-bot` image
+    - 1 x 1Gi DO Volume

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ These are the top-level admins of TCD's infrastructure. They approve changes to 
 - Cluster `arealmreborn` (FF14 DC themed)
   - Node pool `primal`
     - Nodes: 1-5, autoscales
+  - Projects bot pod

--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -17,3 +17,10 @@ resource "digitalocean_kubernetes_cluster" "main" {
     max_nodes  = 5
   }
 }
+
+provider "kubernetes" {
+  host                   = digitalocean_kubernetes_cluster.main.kube_config.0.host
+  client_certificate     = digitalocean_kubernetes_cluster.main.kube_config.0.client_certificate
+  client_key             = digitalocean_kubernetes_cluster.main.kube_config.0.client_key
+  cluster_ca_certificate = digitalocean_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate
+}

--- a/src/projects-bot.tf
+++ b/src/projects-bot.tf
@@ -31,8 +31,8 @@ resource "kubernetes_pod" "projects-bot" {
         for_each = var.projects_bot_env_vars
 
         content {
-          name  = each.key
-          value = each.value
+          name  = env.key
+          value = env.value
         }
       }
     }

--- a/src/projects-bot.tf
+++ b/src/projects-bot.tf
@@ -1,0 +1,46 @@
+resource "kubernetes_persistent_volume_claim" "data" {
+  metadata {
+    name = "data"
+  }
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    resources {
+      requests = {
+        storage = "1Gi"
+      }
+    }
+    storage_class_name = "do-block-storage"
+  }
+}
+
+resource "kubernetes_pod" "projects-bot" {
+  metadata {
+    name = "projects-bot"
+  }
+  spec {
+    container {
+      image = "thecodingden/projects-bot"
+      name  = "projects-bot"
+
+      env {
+        name  = "DISCORD_CLIENT_TOKEN"
+        value = var.projects_bot_token
+      }
+
+      dynamic "env" {
+        for_each = var.projects_bot_env_vars
+
+        content {
+          name  = each.key
+          value = each.value
+        }
+      }
+    }
+    volume {
+      name = "data"
+      persistent_volume_claim {
+        claim_name = kubernetes_persistent_volume_claim.data.metadata[0].name
+      }
+    }
+  }
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,4 +1,6 @@
-variable "projects_bot_token" {}
+variable "projects_bot_token" {
+  type = string
+}
 
 variable "projects_bot_env_vars" {
   type = map(string)

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,0 +1,5 @@
+variable "projects_bot_token" {}
+
+variable "projects_bot_env_vars" {
+  type = map(string)
+}


### PR DESCRIPTION
This pull request provisions resources for the new projects bot.

## Resource impact
- Memory: Negligible
- Disk: Negligible, at least initially. As the database grows this may change, but that's quite far into the future, and the volume has been provisioned such that there shouldn't be risk of filling it at any point in the indexable future.
- Added 1 GB data volume for persistent storage of project data.

## Pre-merge ToDo
1. [x] Add bot to guild
2. [x] Create submission channel in the guild and setup permissions
3. [x] (Optional) Create submission discussion channel
4. [x] Create submission webhook, add it to the channel and link it to the form
5. [x] Set Terraform variables for non-default-valid environment variables (Token, channel/role/webhook IDs)

## Checklist
- [x] I ran a formatter on all changes in this PR.
- [x] I have sent any relevant secrets to infrastructure admins.
- [x] I have ensured that any software changes are tested and have passed for the versions included.
- [x] I have added the changes to the resource tree in `README.md`.
