### PR TITLE
Prevent Kubernetes from falling back on .kube/config

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -23,4 +23,5 @@ provider "kubernetes" {
   client_certificate     = digitalocean_kubernetes_cluster.main.kube_config.0.client_certificate
   client_key             = digitalocean_kubernetes_cluster.main.kube_config.0.client_key
   cluster_ca_certificate = digitalocean_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate
+  load_config_file       = false
 }


### PR DESCRIPTION
Fixes problems with [the projects bot deployment](https://app.terraform.io/app/TheCodingDen/workspaces/infra/runs/run-c1QdxfGnhmPBPo9s) falling back on `.kube/config` when provider configuration is incomplete (Sourced from https://github.com/hashicorp/terraform-provider-kubernetes/issues/168#issuecomment-396389275).

## Resource impact
N/A

## Pre-merge ToDo
N/A

## Checklist
- [x] I ran a formatter on all changes in this PR.
- [x] I have sent any relevant secrets to infrastructure admins.
- [x] I have ensured that any software changes are tested and have passed for the versions included.
- [x] I have added the changes to the resource tree in `README.md`.
