### PR TITLE
Fix CA certificate not being decoded

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -22,6 +22,6 @@ provider "kubernetes" {
   host                   = digitalocean_kubernetes_cluster.main.kube_config.0.host
   client_certificate     = digitalocean_kubernetes_cluster.main.kube_config.0.client_certificate
   client_key             = digitalocean_kubernetes_cluster.main.kube_config.0.client_key
-  cluster_ca_certificate = digitalocean_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate
+  cluster_ca_certificate = base64decode(digitalocean_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate)
   load_config_file       = false
 }


### PR DESCRIPTION
Sourced from https://github.com/hashicorp/terraform-provider-helm/issues/37#issuecomment-359301875 and [Terraform Kubernetes provider example](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster#kubernetes-terraform-provider-example).

## Resource impact
N/A

## Pre-merge ToDo
N/A

## Checklist
- [x] I ran a formatter on all changes in this PR.
- [x] I have sent any relevant secrets to infrastructure admins.
- [x] I have ensured that any software changes are tested and have passed for the versions included.
- [x] I have added the changes to the resource tree in `README.md`.
