### PR TITLE
Hotfix: remove Volume name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ crash.log
 # version control.
 #
 # example.tfvars
+*.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/src/projects-bot.tf
+++ b/src/projects-bot.tf
@@ -10,7 +10,6 @@ resource "kubernetes_persistent_volume_claim" "data" {
     namespace = kubernetes_namespace.projects_bot_ns.id
   }
   spec {
-    volume_name = "projects-bot-data"
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
@@ -23,7 +22,7 @@ resource "kubernetes_persistent_volume_claim" "data" {
 
 resource "kubernetes_deployment" "projects_bot" {
   metadata {
-    name = "projects-bot-deployment"
+    name      = "projects-bot-deployment"
     namespace = kubernetes_namespace.projects_bot_ns.id
   }
   spec {
@@ -55,7 +54,7 @@ resource "kubernetes_deployment" "projects_bot" {
         volume {
           name = "projects-bot-pvc"
           persistent_volume_claim {
-              claim_name = kubernetes_persistent_volume_claim.data.metadata[0].name
+            claim_name = kubernetes_persistent_volume_claim.data.metadata[0].name
           }
         }
       }


### PR DESCRIPTION
The suggested fix is to remove the Volume name, as DO for some reason doesn't fall back on creating a Volume with the name if the name can't be found.

## Checklist
- [x] I ran a formatter on all changes in this PR.
- N/A I have sent any relevant secrets to infrastructure admins.
- N/A I have ensured that any software changes are tested and have passed for the versions included.
- [x] I have added the changes to the resource tree in `README.md`.
