### PR TITLE
Add utilities-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ These are the top-level admins of TCD's infrastructure. They approve changes to 
   - Projects Bot
     - 1 pod w/ `thecodingden/projects-bot` image
     - 1 x 1Gi DO Volume
+  - Utilities Bot
+    - 1 pod w/ `thecodingden/tcd-utilities-bot` image
 
 ## Misc notes
 <details><summary><b>Prefer explicit K8s Deployments over Pods</b></summary>

--- a/src/utilities-bot.tf
+++ b/src/utilities-bot.tf
@@ -1,0 +1,48 @@
+resource "kubernetes_namespace" "utilities_bot_ns" {
+  metadata {
+    name = "utilities-bot"
+  }
+}
+
+resource "kubernetes_deployment" "utilities_bot" {
+  metadata {
+    name      = "utilities-bot-deployment"
+    namespace = kubernetes_namespace.utilities_bot_ns.id
+  }
+  spec {
+    selector {
+      match_labels = {
+        ident = "utilities-bot"
+        type  = "discord-bot"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          ident = "utilities-bot"
+          type  = "discord-bot"
+        }
+      }
+      spec {
+        container {
+          image = "thecodingden/tcd-utilities-bot"
+          name  = "utilities-bot"
+
+          env {
+            name  = "TOKEN"
+            value = var.utilities_bot_token
+          }
+
+          dynamic "env" {
+            for_each = var.utilities_bot_env_vars
+
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -5,3 +5,11 @@ variable "projects_bot_token" {
 variable "projects_bot_env_vars" {
   type = map(string)
 }
+
+variable "utilities_bot_token" {
+  type = string
+}
+
+variable "utilities_bot_env_vars" {
+  type = map(string)
+}


### PR DESCRIPTION
This PR adds a prod for the utilities bot located [here](https://github.com/TheCodingDen/tcd-utilities-bot).

The bot only includes the nomination archival for now, but should be the go-to for any future tasks that should be automated for TCD Staff.

## Resource impact
- Docker image has size of ~1 Gig
- Container should only consume a negligible amount of resources while idle. Limited set of Discord Intents and not doing any work unless a command is triggered
- No Volume needed. No persistent storage

## Pre-merge ToDo
1. [x] Create Bot in the [Discord Developer Portal](https://discord.com/developers/applications)
2. [x] Create necessary entries (including ENV vars) on the web interface of terraform

## Checklist
- [x] I ran a formatter on all changes in this PR. - Through terraform validate
- [x] I have sent any relevant secrets to infrastructure admins. - Also visible via .env.example in the bot repo
- [x] I have ensured that any software changes are tested and have passed for the versions included. - Bot (including docker image) tested on local machine
- [x] I have added the changes to the resource tree in `README.md`.
